### PR TITLE
fix ajaxrequests loading a full page

### DIFF
--- a/Subscriber/Frontend/FilterRender.php
+++ b/Subscriber/Frontend/FilterRender.php
@@ -69,7 +69,7 @@ class FilterRender implements SubscriberInterface
             !empty($containerId) &&
             strtolower($this->container->get('front')->Request()->getModuleName()) != 'backend'
         ) {
-            if (!$this->container->get('front')->Request()->isXmlHttpRequest()) {
+            if (!$this->container->get('front')->Request()->isXmlHttpRequest() || strpos($source, '<html') !== false) {
                 $headTag = file_get_contents($this->container->getParameter('wbm_tag_manager.plugin_dir') . '/Resources/tags/head.html');
                 $bodyTag = file_get_contents($this->container->getParameter('wbm_tag_manager.plugin_dir') . '/Resources/tags/body.html');
 


### PR DESCRIPTION
This fixes as bug with the conexco bootstrap theme's ajax filter and shopware 5.2 (and all other ajax requests which load a complete html page)

1) enable the http cache
2) enable the ajax filter of the bootstrap theme
3) filter the product listing and go to the detail page of a product
4) go back to the filtered listing

Now there is a js error "Uncaught TypeError: Cannot read property 'push' of undefined".
This happens because the tag manager prepends its js to the html which is loaded in the ajax request. In most cases this is perfectly fine. But if you load a complete html page, the js is in front of the <html> tag

`
<script>window.dataLayer.push({"ecommerce":{"currencyCode":"EUR", [...]}</script>
<!DOCTYPE html>
<html lang="de">
`
and the 
`<script>window.dataLayer = window.dataLayer || [];</script>`
is missing.

While the ajax request and filter works perfectly fine, this corrupted page ist cached in the http cache and will be loaded again when you make a "normal" request to that page.
