### PR TITLE
Decode html special chars

### DIFF
--- a/Subscriber/Frontend/FilterRender.php
+++ b/Subscriber/Frontend/FilterRender.php
@@ -118,6 +118,9 @@ class FilterRender implements SubscriberInterface
             case is_int(json_decode($value)):
             case is_float(json_decode($value)):
                 $value = json_decode($value);
+                break;
+            default:
+                $value = htmlspecialchars_decode($value, ENT_QUOTES);
         }
     }
 


### PR DESCRIPTION
Strings containing quotation marks are currently html encoded
For example, `15" screen` is sent to GTM as `15&quot; screen`