### PR TITLE
fixes newline in listing body tag

### DIFF
--- a/Subscriber/Frontend/FilterRender.php
+++ b/Subscriber/Frontend/FilterRender.php
@@ -94,7 +94,7 @@ class FilterRender implements SubscriberInterface
                  * the body tag with any attributes in it
                  * everything following the body tag
                  */
-                $matches = preg_split('/(<body.*?>)/i', $source, 2, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+                $matches = preg_split('/(?<!\\\n)(<body.*?\n*?.*>)/i', $source, 2, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 
                 if (!empty($matches)) {
                     /* assemble the HTML output back with the iframe code in it */


### PR DESCRIPTION
For the reason i don't know why in listing the body tag gets a newline after class="
because of that the noscript tags gets after the closing </html> tag with the old regex

this also fixes if there is a {debug} tag in ahead of the shopware body tag

negative lookbehind for \n  because the smarty debug get's a \n in the iframe {debug} tag

Demoshop of Shopware the sourcecode has a \n after the class=" in body tag
https://www.shopwaredemo.de/hoehenluft-abenteuer/ausruestung/zubehoer/bindungen/

https://regex101.com/r/mV5E86/3
See regex examples