### PR TITLE
Remove value's length restriction to 255 chars

### DIFF
--- a/Models/Property.php
+++ b/Models/Property.php
@@ -54,7 +54,7 @@ class Property extends ModelEntity
 
     /**
      * @var string
-     * @ORM\Column(name="value", type="string", length=255, nullable=false)
+     * @ORM\Column(name="value", type="text", nullable=false)
      */
     private $value = '';
 

--- a/Resources/sql/install.sql
+++ b/Resources/sql/install.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `wbm_data_layer_modules` ( `id` INT(11) NOT NULL AUTO_INCREMENT , `module` VARCHAR(255) NOT NULL , `variables` LONGTEXT NULL , PRIMARY KEY (`id`)) ENGINE = InnoDB;
 
-CREATE TABLE IF NOT EXISTS `wbm_data_layer_properties` ( `id` INT(11) NOT NULL AUTO_INCREMENT , `module` VARCHAR(255) NOT NULL , `parentID` INT(11) NOT NULL DEFAULT '0' , `name` VARCHAR(255) NOT NULL , `value` VARCHAR(255) NOT NULL , PRIMARY KEY (`id`)) ENGINE = InnoDB;
+CREATE TABLE IF NOT EXISTS `wbm_data_layer_properties` ( `id` INT(11) NOT NULL AUTO_INCREMENT , `module` VARCHAR(255) NOT NULL , `parentID` INT(11) NOT NULL DEFAULT '0' , `name` VARCHAR(255) NOT NULL , `value` TEXT NOT NULL , PRIMARY KEY (`id`)) ENGINE = InnoDB;
 
 INSERT IGNORE INTO `wbm_data_layer_modules` (`id`, `module`, `variables`) VALUES
   (1, 'frontend_listing_index', NULL),

--- a/Resources/sql/update.2.1.9.sql
+++ b/Resources/sql/update.2.1.9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `wbm_data_layer_properties`
+MODIFY COLUMN `value` TEXT;

--- a/WbmTagManager.php
+++ b/WbmTagManager.php
@@ -75,6 +75,10 @@ class WbmTagManager extends \Shopware\Components\Plugin
             $sql .= file_get_contents($this->getPath() . '/Resources/sql/update.2.1.2.sql');
             $this->container->get('shopware.db')->query($sql);
         }
+        if (version_compare($currentVersion, '2.1.9', '<')) {
+            $sql .= file_get_contents($this->getPath() . '/Resources/sql/update.2.1.9.sql');
+            $this->container->get('shopware.db')->query($sql);
+        }
 
         $context->scheduleClearCache(InstallContext::CACHE_LIST_ALL);
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,10 +3,15 @@
     <label lang="de">Tag Manager</label>
     <label lang="en">Tag Manager</label>
 
-    <version>2.1.8</version>
+    <version>2.1.9</version>
     <link>http://www.webmatch.de</link>
     <author>Webmatch GmbH</author>
     <compatibility minVersion="5.2.0" />
+
+    <changelog version="2.1.9">
+        <changes lang="de">Die Werte für Felder im DataLayer können nun größer als 255 Zeichen sein</changes>
+        <changes lang="en">Values for fields in datalayer may now be longer than 255 characters</changes>
+    </changelog>
 
     <changelog version="2.1.8">
         <changes lang="de">Bugfix für mehrfache Array Iterationen</changes>


### PR DESCRIPTION
Yesterday I had some really long smarty expressions I want to be evaluated. Unfortunately, the database column is restricted to 255 chars. This is absolutely suitable for small and easy expressions. But sometimes you need just more. :)