### PR TITLE
Prevent NPE if impressions are not defined in DataLayer

### DIFF
--- a/Resources/views/frontend/_public/src/js/jquery.product-click-tracking.js
+++ b/Resources/views/frontend/_public/src/js/jquery.product-click-tracking.js
@@ -4,6 +4,10 @@
             var me = this;
 
             me.setImpressions();
+            
+            if (me.impressions === undefined) {
+                return;
+            }
 
             me._on(me.$el, 'click', $.proxy(me.onProductClicked, me));
         },


### PR DESCRIPTION
If the array-index "impressions" is not defined in the DataLayer for a controller, where a product-box is used, it comes to a Null-Pointer-Exception.
Therefore a null-check has to be added on initializing.