### PR TITLE
Add custom GTM loader

### DIFF
--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -13,6 +13,18 @@
             <label lang="en">Container ID</label>
             <value/>
         </element>
+        <element scope="shop" type="text">
+            <name>wbmTagManagerDomain</name>
+            <label lang="de">benutzerdefinierte Domain</label>
+            <label lang="en">Custom domain</label>
+            <value/>
+            <description lang="de"><![CDATA[
+                Schreiben Sie die benutzerdefinierte Domain zum Laden des Google Tag Mangers von einem eigenen Server hier rein. Das Google Skript gtm.js kann so direkt von ihrem Server statt den Google-Servern geladen werden. Z.B. www.tagging.example.com
+            ]]></description>
+            <description lang="en"><![CDATA[
+                Enter the custom domain for loading the Google Tag Manager from your own server here. The Google script gtm.js can then be loaded directly from your server instead of the Google servers. E.G. www.tagging.example.com
+            ]]></description>
+        </element>
         <element scope="shop" type="boolean">
             <name>wbmTagManagerCookieConsent</name>
             <label lang="de">Cookie Consent Unterstützung</label>

--- a/Resources/tags/body.html
+++ b/Resources/tags/body.html
@@ -1,4 +1,3 @@
 <!-- WbmTagManager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=%s%s"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript><iframe src="https://%s/ns.html?id=%s%s" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End WbmTagManager (noscript) -->

--- a/Resources/tags/head.html
+++ b/Resources/tags/head.html
@@ -1,5 +1,5 @@
 <!-- WbmTagManager -->
 <script%s>
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'%s';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','%s');
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://%s/gtm.js?id='+i+dl+'%s';f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','%s');
 </script>
 <!-- End WbmTagManager -->

--- a/Resources/tags/pagespeed/head.html
+++ b/Resources/tags/pagespeed/head.html
@@ -5,7 +5,7 @@ var googleTagManagerFunction = function(w,d,s,l,i) {
     w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
     var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
     j.async=true;
-    j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'%s';
+    j.src='https:/%s/gtm.js?id='+i+dl+'%s';
     f.parentNode.insertBefore(j,f);
 };
 

--- a/Resources/views/frontend/index/header.tpl
+++ b/Resources/views/frontend/index/header.tpl
@@ -5,7 +5,7 @@
     {if {config name='wbmTagManagerCookieConsent'}}
         <script>
             {literal}
-            var googleTag = function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'{/literal}{config name='wbmExtendedURLParameter'}{literal}';f.parentNode.insertBefore(j,f);};
+            var googleTag = function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://{/literal}{if {config name='wbmExtendedURLParameter'} != ''}{config name='wbmExtendedURLParameter'}{else}www.googletagmanager.com{/if}{literal}/gtm.js?id='+i+dl+'{/literal}{config name='wbmExtendedURLParameter'}{literal}';f.parentNode.insertBefore(j,f);};
             {/literal}
         </script>
     {/if}

--- a/Subscriber/Frontend/FilterRender.php
+++ b/Subscriber/Frontend/FilterRender.php
@@ -123,6 +123,7 @@ class FilterRender extends ConfigAbstract implements SubscriberInterface
         $containerId,
         $prettyPrint
     ) {
+        $domain = empty($this->pluginConfig('wbmTagManagerDomain')) ? 'www.googletagmanager.com' : $this->pluginConfig('wbmTagManagerDomain');
         $extendedUrlParams = trim($this->pluginConfig('wbmExtendedURLParameter'));
         $headTag = '';
         if (!$this->pluginConfig('wbmTagManagerCookieConsent')) {
@@ -134,13 +135,14 @@ class FilterRender extends ConfigAbstract implements SubscriberInterface
             $headTag = sprintf(
                 $headTag,
                 (!empty($this->pluginConfig('wbmScriptTagAttributes')) ? ' ' . $this->pluginConfig('wbmScriptTagAttributes') : ''),
+                $domain,
                 $extendedUrlParams,
                 $containerId
             );
         }
 
         $bodyTag = file_get_contents($this->pluginDir . '/Resources/tags/body.html');
-        $bodyTag = sprintf($bodyTag, $containerId, $extendedUrlParams);
+        $bodyTag = sprintf($bodyTag, $domain, $containerId, $extendedUrlParams);
 
         $headTag = $this->wrapHeadTag($headTag);
 


### PR DESCRIPTION
Adds the ability to load the gtm.js script from your own server.
[Load Google scripts through server-side tagging &nbsp;|&nbsp; Google Tag Manager - Server-side](https://developers.google.com/tag-platform/tag-manager/server-side/dependency-serving?tag=gtm)